### PR TITLE
Configure the bullet_train submodule so cargo can fetch the repo

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "bullet_train/bullet_train"]
+	path = bullet_train/bullet_train
+	url = https://github.com/bullet-train-co/bullet_train.git
+	branch = main


### PR DESCRIPTION
Closes A1 of #57.

`bullet_train/bullet_train` is recorded in the tree as a gitlink at `dd04621`, but no `.gitmodules` declares its URL. Git tolerates this and warns; cargo updates submodules unconditionally and fails hard, so no application can depend on Anubis from git:

```
error: failed to get `anubis` as a dependency of package `probe v0.1.0`
Caused by: Unable to update https://github.com/JalapenoLabs/Anubis?branch=develop
Caused by: failed to update submodule `bullet_train/bullet_train`
Caused by: no URL configured for submodule 'bullet_train/bullet_train'; class=Submodule (17)
```

This blocks every consumer Anubis has, because `anubis new` stamps applications whose `backend/Cargo.toml` installs the crate straight from this repository (`anubis/templates/new/backend-Cargo.toml`). It reproduces on `develop` and `main`.

## The fix

`dd04621` is a real commit in `bullet-train-co/bullet_train`, so declaring the URL restores the reference submodule CLAUDE.md already documents rather than changing the design.

## Verification

Against this branch, cargo resolves:

```
    Updating git repository `https://github.com/JalapenoLabs/Anubis`
    Updating git submodule `https://github.com/bullet-train-co/bullet_train.git`
     Locking 416 packages to latest compatible versions
      Adding anubis v0.1.0 (https://github.com/JalapenoLabs/Anubis?branch=fix%2Fbullet-train-submodule-url#c0a18f70)
```

The submodule costs consumers a 7.3 MB clone, small enough not to argue over. Dropping the gitlink instead (`git rm --cached bullet_train/bullet_train`) unblocks cargo just as well and spares consumers that clone, but it deletes reference material CLAUDE.md calls for, so this takes the conservative half of the choice #57 offers.

## Context

Filed while standing up [Arsox](https://github.com/JalapenoLabs/arsox) as an Anubis consumer, where this was the first thing in the way.

---
_Generated by [Claude Code](https://claude.ai/code/session_013UuaLrsDKET2xFZYns3oPh)_