### PR TITLE
Build dist on prepack so the frontend package installs from git

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "bullet_train/bullet_train"]
+	path = bullet_train/bullet_train
+	url = https://github.com/bullet-train-co/bullet_train.git
+	branch = main

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -51,6 +51,7 @@
   },
   "scripts": {
     "build": "vite build",
+    "prepack": "yarn build",
     "clean": "rimraf dist coverage",
     "typecheck": "tsc --noEmit",
     "lint": "eslint . --max-warnings 0",


### PR DESCRIPTION
Stacked on #66, so the diff shows that commit too until it merges. The change here is one line in `frontend/package.json`.

## The problem

`anubis new` stamps applications whose frontend depends on `@jalapenolabs/anubis` straight from this repository, because the package is not published yet (`anubis/src/cli/new.rs`, and D1 of #57):

```json
"@jalapenolabs/anubis": "https://github.com/JalapenoLabs/Anubis.git#workspace=@jalapenolabs/anubis"
```

That dependency installs empty. `files` is `["dist"]`, nothing builds `dist` during a git install, and the consumer ends up with a node_modules directory holding `package.json` and nothing else:

```
node_modules/@jalapenolabs/anubis/
└── package.json
```

So every stamped application fails on its first `yarn typecheck`, once per importing file:

```
src/pages/DashboardPage.tsx(6,46): error TS2307: Cannot find module
  '@jalapenolabs/anubis' or its corresponding type declarations.
```

The monorepo does not see it because `starter/frontend` resolves the package through `workspace:^`.

## The fix

Yarn runs `prepack` when it installs a workspace from git, so pointing it at the existing build script produces the dist the consumer imports.

## Verification

Stamped a fresh application with `anubis new`, pointed its frontend at this commit, and installed:

```
node_modules/@jalapenolabs/anubis/dist/
├── index.cjs
├── index.cjs.map
├── index.d.ts
├── index.js
└── index.js.map
```

`yarn typecheck` then passes clean across the whole stamped app, where before it reported 15 errors.

Publishing to npm (#56, D1 of #57) makes this redundant, and it costs consumers a framework build on install until then. Both are arguments for publishing rather than against the line.

## Context

Filed while standing up [Arsox](https://github.com/JalapenoLabs/arsox) as an Anubis consumer.

---
_Generated by [Claude Code](https://claude.ai/code/session_013UuaLrsDKET2xFZYns3oPh)_