### PR TITLE
Name the database address so a new pool connection cannot stall 21 seconds

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,7 +13,14 @@ POSTGRES_DB=anubis_starter_development
 # Off the default port, so a Postgres already running on the host never
 # collides with this one.
 POSTGRES_PORT=54321
-DATABASE_URL=postgres://anubis_starter:anubis-starter-dev-password@localhost:54321/anubis_starter_development
+# 127.0.0.1 rather than localhost, because Docker publishes this port on IPv4
+# and `localhost` resolves to ::1 first on a dual-stack host. The driver tries
+# the addresses in the order it is given them, so ::1 costs a full TCP connect
+# timeout, around 21 seconds on Windows, every time the pool opens a
+# connection. The request that pays it succeeds, which is what makes it look
+# like the application stalled rather than the address being wrong. CI names
+# the address too, so both stacks reach Postgres the same way.
+DATABASE_URL=postgres://anubis_starter:anubis-starter-dev-password@127.0.0.1:54321/anubis_starter_development
 
 # The origin the browser sees, which in development is the Vite dev server.
 # Email links and OAuth redirect URIs are built from it.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -201,12 +201,12 @@ jobs:
   # Browser-level proof that the starter's screens work against the real stack:
   # Postgres, the Rust backend, and Vite, driven by Chromium.
   #
-  # Advisory to start with. Playwright's browsers need system libraries the
-  # self-hosted Rocky 9 runners are not guaranteed to carry, and `playwright
-  # install --with-deps` shells out to the system package manager as root,
-  # which a runner may refuse; a missing libatk must not block unrelated work
-  # from merging. Flip continue-on-error to false once a run on a fresh runner
-  # provisions its browser cleanly, the same convention the audits above use.
+  # Advisory. Playwright's browsers need system libraries the self-hosted
+  # Rocky 9 runners are not guaranteed to carry, and Playwright installs them
+  # through the system package manager as root, which a runner may refuse; a
+  # missing libatk must not block unrelated work from merging. Flip
+  # continue-on-error to false once a run on a fresh runner provisions its
+  # browser cleanly, the same convention the audits above use.
   e2e:
     name: E2E
     runs-on: [self-hosted, rocky9, earthly, docker]
@@ -252,13 +252,22 @@ jobs:
       - name: Build the backend
         run: cargo build -p anubis-starter
 
-      # Idempotent: the runner keeps ~/.cache/ms-playwright between runs, so
-      # only a fresh runner pays the download. Allowed to fail on its own,
-      # because a runner that already carries the libraries still runs the
-      # suite, and the failure is worth seeing in the log either way.
-      - name: Install Chromium
+      # The system libraries Chromium links against are the runner's to carry,
+      # and Playwright installs them through the system package manager as
+      # root, which these Rocky 9 runners have no apt-get for. Asking for them
+      # separately is what keeps that refusal from taking the browser download
+      # with it: a runner that already carries the libraries runs the suite
+      # either way, and the failure is worth seeing in the log.
+      - name: Install Chromium system dependencies
         continue-on-error: true
-        run: yarn workspace anubis-starter-frontend exec playwright install --with-deps chromium
+        run: yarn workspace anubis-starter-frontend exec playwright install-deps chromium
+
+      # Idempotent: the runner keeps ~/.cache/ms-playwright between runs, so
+      # only a fresh runner pays the download. A browser that will not download
+      # fails the step, because every spec after it fails on a missing
+      # executable and says nothing about the application.
+      - name: Install Chromium
+        run: yarn workspace anubis-starter-frontend exec playwright install chromium
 
       # The suite drives the same three processes `yarn dev` starts. Playwright
       # waits for the stack itself (e2e/global-setup.ts), so this step starts

--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ is held to:
 
 ```sh
 docker compose --env-file .env.example -f starter/compose.yaml up -d --wait
-DATABASE_URL=postgres://anubis_starter:anubis-starter-dev-password@localhost:54321/anubis_starter_development \
+DATABASE_URL=postgres://anubis_starter:anubis-starter-dev-password@127.0.0.1:54321/anubis_starter_development \
   bash scripts/ci-scaffold-proof.sh
 ```
 

--- a/anubis/templates/new/env.example
+++ b/anubis/templates/new/env.example
@@ -13,7 +13,14 @@ POSTGRES_DB=anubis_starter_development
 # Off the default port, so a Postgres already running on the host never
 # collides with this one.
 POSTGRES_PORT=54321
-DATABASE_URL=postgres://anubis_starter:anubis-starter-dev-password@localhost:54321/anubis_starter_development
+# 127.0.0.1 rather than localhost, because Docker publishes this port on IPv4
+# and `localhost` resolves to ::1 first on a dual-stack host. The driver tries
+# the addresses in the order it is given them, so ::1 costs a full TCP connect
+# timeout, around 21 seconds on Windows, every time the pool opens a
+# connection. The request that pays it succeeds, which is what makes it look
+# like the application stalled rather than the address being wrong. CI names
+# the address too, so both stacks reach Postgres the same way.
+DATABASE_URL=postgres://anubis_starter:anubis-starter-dev-password@127.0.0.1:54321/anubis_starter_development
 
 # The origin the browser sees, which in development is the Vite dev server.
 # Email links and OAuth redirect URIs are built from it.

--- a/anubis/tests/login_storm.rs
+++ b/anubis/tests/login_storm.rs
@@ -26,7 +26,7 @@
 //! Run it deliberately:
 //!
 //! ```sh
-//! DATABASE_URL=postgres://app:app@localhost:54321/app_development \
+//! DATABASE_URL=postgres://app:app@127.0.0.1:54321/app_development \
 //! RATE_LIMIT_DISABLED=true \
 //!   cargo test --release -p anubis-framework --test login_storm -- --ignored --nocapture
 //! ```

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -45,7 +45,7 @@ Run the same proof before touching a living template, with `yarn dev` stopped:
 
 ```sh
 docker compose --env-file .env.example -f starter/compose.yaml up -d --wait
-DATABASE_URL=postgres://anubis_starter:anubis-starter-dev-password@localhost:54321/anubis_starter_development \
+DATABASE_URL=postgres://anubis_starter:anubis-starter-dev-password@127.0.0.1:54321/anubis_starter_development \
   bash scripts/ci-scaffold-proof.sh
 ```
 

--- a/docs/scaffolding.md
+++ b/docs/scaffolding.md
@@ -797,7 +797,7 @@ CI runs it on every push and pull request, and the job is blocking. Run it yours
 
 ```sh
 docker compose --env-file .env.example -f starter/compose.yaml up -d --wait
-DATABASE_URL=postgres://anubis_starter:anubis-starter-dev-password@localhost:54321/anubis_starter_development \
+DATABASE_URL=postgres://anubis_starter:anubis-starter-dev-password@127.0.0.1:54321/anubis_starter_development \
   bash scripts/ci-scaffold-proof.sh
 ```
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -62,7 +62,7 @@ yarn workspace anubis-starter-frontend test:e2e   # in a second terminal
 
 Or `yarn e2e` from the repository root, which starts all three, runs the specs, and stops the servers however the run ended. `yarn playwright install chromium` provisions the browser once per machine.
 
-`yarn e2e` starts the backend with `RATE_LIMIT_DISABLED=true`, and CI does the same. Each spec registers an account, which is a rate no person reaches and the auth limiter refuses with a `429`; the limiter is exactly what [api.md](api.md#rate-limiting) says it is, a budget for suites that drive these endpoints hard from one address, and it has its own Rust narrative. Running the suite against a stack started by a plain `yarn dev` works until the third sign-up.
+`yarn e2e` starts the backend with `RATE_LIMIT_DISABLED=true`, and CI does the same. Each spec registers an account, which is a rate no person reaches and the auth limiter refuses with a `429`; the limiter is exactly what [api.md](api.md#rate-limiting) says it is, a budget for suites that drive these endpoints hard from one address, and it has its own Rust narrative. A stack started by a plain `yarn dev` enforces it, and its budget is ten registrations an hour against three sign-ups a run, so a fourth consecutive run runs out partway through. `signUp` reads the registration response and fails with that reason and the variable to set, because the alternative is three specs timing out on a dashboard heading that was never going to render.
 
 `E2E_BASE_URL` points the specs somewhere else, which is what CI sets and what running them against a deployed environment needs. Vite runs with `strictPort`, so 5173 being taken is an error rather than a quiet move to 5174: `APP_URL` names that origin, and every email link, OAuth redirect, and Stripe return is built from it.
 
@@ -92,6 +92,8 @@ A page can render several forms with identically labelled fields, a show page ho
 ### Flake
 
 Retries are off and there are no sleeps. Playwright's auto-waiting is the only synchronization the specs use, so a spec that needs a sleep is reporting something real about the application. A retry would hide exactly that, and a suite whose failures are not believed is worse than no suite. Specs run one at a time (`workers: 1`) so that a failure reads as one story rather than three interleaved ones.
+
+The suite submits a create form faster than the list beside it can load, which a person never does, so a scaffolded section has to hold one invariant: a write revalidates its own list, and the read that was already in flight when the write landed is discarded rather than rendered over the result. `mutate()` after the write is what states it, and `src/pages/CreativeConceptPage.test.tsx` pins it by holding the section's first list read open until after the create.
 
 ## Test-database isolation
 

--- a/scripts/ci-scaffold-proof.sh
+++ b/scripts/ci-scaffold-proof.sh
@@ -11,7 +11,7 @@
 # with `yarn dev` stopped:
 #
 #   docker compose --env-file .env.example -f starter/compose.yaml up -d --wait
-#   DATABASE_URL=postgres://anubis_starter:anubis-starter-dev-password@localhost:54321/anubis_starter_development \
+#   DATABASE_URL=postgres://anubis_starter:anubis-starter-dev-password@127.0.0.1:54321/anubis_starter_development \
 #     bash scripts/ci-scaffold-proof.sh
 #
 # It writes generated models into starter/ and leaves them there, so the output

--- a/starter/frontend/e2e/support/app.ts
+++ b/starter/frontend/e2e/support/app.ts
@@ -1,6 +1,6 @@
 // Copyright © 2026 Jalapeno Labs
 
-import type { Page } from '@playwright/test'
+import type { Page, Response } from '@playwright/test'
 
 // Core
 import { expect } from '@playwright/test'
@@ -62,7 +62,9 @@ export async function signUp(page: Page, purpose: string): Promise<Account> {
 
   await page.goto(UrlTree.signUp)
   await fillCredentials(page, account)
+  const registration = page.waitForResponse(byPath('/auth/register'))
   await page.getByRole('button', { name: strings.auth.signUp.action }).click()
+  expectAuthAccepted(await registration)
   await expectDashboard(page)
 
   return account
@@ -71,8 +73,49 @@ export async function signUp(page: Page, purpose: string): Promise<Account> {
 /** Signs `account` in from the sign-in page the browser is already on. */
 export async function signIn(page: Page, account: Account): Promise<void> {
   await fillCredentials(page, account)
+  const login = page.waitForResponse(byPath('/auth/login'))
   // Exactly, because the page also offers "Sign in with a passkey".
   await page.getByRole('button', { name: strings.auth.signIn.action, exact: true }).click()
+  expectAuthAccepted(await login)
+}
+
+/** Matches the response to `path`, whatever origin the run is driving. */
+function byPath(path: string) {
+  return (response: Response) => new URL(response.url()).pathname === path
+}
+
+/**
+ * Fails with the reason when the backend refuses an auth request.
+ *
+ * Every spec starts by signing up and one of them signs back in, so a refusal
+ * leaves the browser on the form it submitted and every assertion after it
+ * times out against a screen that was never going to render. Read on its own,
+ * that failure says only that a heading is missing, which is the least useful
+ * true thing the suite could report.
+ *
+ * The rate limiter is the refusal that actually happens. The suite registers
+ * an account per spec, the limiter budgets registrations per client address,
+ * and a stack that enforces it therefore runs out partway through a few
+ * consecutive runs, which reads as a spec that passed twice and then failed
+ * for no reason.
+ */
+function expectAuthAccepted(response: Response): void {
+  if (response.ok()) {
+    return
+  }
+
+  const { pathname } = new URL(response.url())
+  if (response.status() === 429) {
+    throw new Error(
+      `${pathname} answered 429 Too Many Requests.\n`
+      + 'This suite spends auth budgets no person reaches: it registers an account per spec, and\n'
+      + 'the limiter counts registrations per client address, so a stack that enforces it runs out\n'
+      + 'after a few consecutive runs.\n'
+      + 'Start the backend with RATE_LIMIT_DISABLED=true, which is what `yarn e2e` and CI do.',
+    )
+  }
+
+  throw new Error(`${pathname} answered ${response.status()}, so the account never signed in.`)
 }
 
 /**

--- a/starter/frontend/src/pages/CreativeConceptPage.test.tsx
+++ b/starter/frontend/src/pages/CreativeConceptPage.test.tsx
@@ -1,0 +1,173 @@
+// Copyright © 2026 Jalapeno Labs
+
+// UI
+import { App } from '../App'
+
+// Utility
+import { describe, expect, it, vi } from 'vitest'
+import { fireEvent, screen, waitFor, within } from '@testing-library/react'
+
+// Misc
+import { renderWithProviders } from '../testing/harness'
+import { getCreativeConceptUrl } from '../urls'
+
+const ORGANIZATION_ID = '5c1a2b3c-0000-4000-8000-000000000001'
+const TEAM_ID = '5c1a2b3c-0000-4000-8000-0000000000aa'
+const CONCEPT_ID = '5c1a2b3c-0000-4000-8000-0000000000bb'
+const THING_ID = '5c1a2b3c-0000-4000-8000-0000000000cc'
+
+const CONCEPT_PATH = `/account/creative-concepts/${CONCEPT_ID}`
+const THINGS_PATH = `${CONCEPT_PATH}/tangible-things`
+
+/** The signed-in account, an admin so the create form renders. */
+const USER = {
+  id: '5c1a2b3c-0000-4000-8000-0000000000ff',
+  email: 'owner@example.com',
+  email_verified: true,
+  first_name: null,
+  last_name: null,
+  time_zone: 'UTC',
+  locale: 'en-US',
+  created_at: '2026-01-01T00:00:00Z',
+}
+
+const MEMBERSHIPS = {
+  organizations: [
+    {
+      id: ORGANIZATION_ID,
+      name: 'Acme',
+      roles: [ 'admin' ],
+      teams: [
+        {
+          id: TEAM_ID,
+          name: 'Acme HQ',
+          roles: [ 'admin' ],
+        },
+      ],
+    },
+  ],
+}
+
+const CONCEPT = {
+  id: CONCEPT_ID,
+  team_id: TEAM_ID,
+  name: 'Weather balloon',
+  description: null,
+  created_at: '2026-01-01T00:00:00Z',
+  updated_at: '2026-01-01T00:00:00Z',
+}
+
+const CREATED_THING = {
+  id: THING_ID,
+  creative_concept_id: CONCEPT_ID,
+  name: 'Altimeter',
+  description: null,
+  created_at: '2026-01-02T00:00:00Z',
+  updated_at: '2026-01-02T00:00:00Z',
+}
+
+function pageOf(tangibleThings: unknown[]) {
+  return {
+    tangible_things: tangibleThings,
+    pagination: {
+      page: 1,
+      limit: 10,
+      total_items: tangibleThings.length,
+      total_pages: tangibleThings.length ? 1 : 0,
+    },
+  }
+}
+
+function jsonResponse(status: number, body: unknown) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  })
+}
+
+/**
+ * A backend whose first list read is held open until the test releases it.
+ *
+ * That read is the one the section starts as it mounts, and Playwright fills
+ * and submits the create form faster than it can answer, which a person never
+ * does. Holding it here reproduces that ordering deterministically, so what
+ * the section does with a read that lands after the write is pinned rather
+ * than left to how quickly a machine happens to answer.
+ */
+function stubBackendWithHeldFirstRead() {
+  let releaseFirstRead = () => {}
+  const firstReadHeld = new Promise<void>((resolve) => {
+    releaseFirstRead = resolve
+  })
+  let listReads = 0
+
+  vi.stubGlobal('fetch', async (input: Request | string | URL, init?: RequestInit) => {
+    const requested = input instanceof Request
+      ? input.url
+      : String(input)
+    const { pathname } = new URL(requested, 'http://localhost')
+    const method = input instanceof Request
+      ? input.method
+      : init?.method ?? 'GET'
+
+    if (pathname === '/auth/me') {
+      return jsonResponse(200, { user: USER })
+    }
+    if (pathname === '/tenancy/memberships') {
+      return jsonResponse(200, MEMBERSHIPS)
+    }
+    if (pathname === '/account/notifications') {
+      return jsonResponse(200, { notifications: [], unread_count: 0 })
+    }
+    if (pathname === CONCEPT_PATH) {
+      return jsonResponse(200, { creative_concept: CONCEPT })
+    }
+    if (pathname === THINGS_PATH && method === 'POST') {
+      return jsonResponse(201, { tangible_thing: CREATED_THING })
+    }
+    if (pathname === THINGS_PATH) {
+      listReads += 1
+      if (listReads === 1) {
+        await firstReadHeld
+        // Answered from before the write, which is what makes it stale.
+        return jsonResponse(200, pageOf([]))
+      }
+      return jsonResponse(200, pageOf([ CREATED_THING ]))
+    }
+
+    console.debug('the creative concept page asked for an unstubbed path', pathname)
+    return jsonResponse(404, {})
+  })
+
+  return { releaseFirstRead }
+}
+
+describe('CreativeConceptPage', () => {
+  it('should show a created tangible thing while the first list read is still in flight', async () => {
+    const { releaseFirstRead } = stubBackendWithHeldFirstRead()
+
+    renderWithProviders(<App />, getCreativeConceptUrl(CONCEPT_ID))
+
+    // The page carries two forms with a field labelled "Name", so the create
+    // form is addressed by the button that says what it is for.
+    const createAction = await screen.findByRole('button', { name: 'Create tangible thing' })
+    const createForm = createAction.closest('form')
+    if (!createForm) {
+      throw new Error('the create action is not inside a form, so this test cannot submit one')
+    }
+
+    const nameField = within(createForm).getByLabelText('Name')
+    fireEvent.change(nameField, { target: { value: CREATED_THING.name }})
+    fireEvent.submit(createForm)
+
+    // The write revalidates the list itself rather than waiting for whatever
+    // revalidation happens next, so the row is there without the held read.
+    expect(await screen.findByText(CREATED_THING.name)).toBeTruthy()
+
+    // And the read that was in flight when the write landed is discarded, not
+    // rendered over the result.
+    releaseFirstRead()
+    await waitFor(() => expect(screen.getByText(CREATED_THING.name)).toBeTruthy())
+    expect(screen.queryByText('No tangible things yet. Add the first one below.')).toBeNull()
+  })
+})


### PR DESCRIPTION
Fixes #98

## What the flake actually was

The issue reads the request log as a section rendering a stale list over a fresh write. It is not that. The 21 second gap in that log is a request that was answered 21 seconds late, and the cause is one word in `.env.example`.

`DATABASE_URL` named `localhost`. On a dual-stack host that resolves to `::1` first, Docker publishes the port on IPv4 only, and tokio-postgres tries the addresses in the order it is given them. So every connection the pool opened attempted `::1`, waited out the OS TCP connect timeout, about 21 seconds on Windows, and then succeeded on `127.0.0.1`. The request that paid it returned 200, which is exactly why it reads as the application stalling rather than the address being wrong. CI already names `127.0.0.1`, so the job never saw it.

Measured on the failing machine, first suite run after a cold backend:

```
localhost                                  127.0.0.1
GET /tenancy/memberships -> 401 (21084ms)  no request over 400ms
GET /account/notifications -> 401 (21085ms)
GET /tenancy/memberships -> 200 (21051ms)
GET /tenancy/memberships -> 200 (21084ms)
GET /account/notifications -> 200 (21086ms)
```

Postgres logged the incoming TCP connection 40ms before the backend logged the response, so the whole 21 seconds is spent before Postgres sees the connection at all.

The visible failure is `creative-concepts.spec.ts` timing out on the list page, because `/tenancy/memberships` is the request that stalls and the page renders "Select a team to see its creative concepts." until it answers. `settings.spec.ts` fails in the same window for the same reason.

## The section does not race its own initial fetch

Checked directly rather than assumed. A Playwright probe held the section's first list read open across the write, sweeping the hold from 100ms to 550ms over 15 iterations with a fresh account each time: the created row appeared every time and survived the held read landing every time. SWR's `mutate()` after the write invalidates the in-flight request marker and starts a new read, and the superseded response is discarded on the timestamp guard. `CreativeConceptPage.test.tsx` now pins that invariant in CI, and it fails if the post-write `mutate()` is removed.

## The other way this suite fails without saying so

While reproducing, the suite ran against a stack without `RATE_LIMIT_DISABLED`, which is what a plain `yarn dev` starts. The registration budget is ten an hour against three sign-ups a run, so a fourth consecutive run runs out partway through and produces `2 failed, 1 passed (14.7s)`, three specs timing out on a dashboard heading with no mention of a 429. `signUp` and `signIn` now read the response and report the status, the budget behind it, and the variable to set. The failures drop from 5.9s of silence to 520ms with the reason.

## Verification

`yarn typecheck`, `yarn lint`, `yarn test` (155 tests) and `cargo test --workspace --lib` (342 tests) all pass. `cargo fmt --check` and `cargo clippy --workspace --all-targets` are clean.

End-to-end against the real stack, six consecutive runs from a cold backend, which is the state that failed before:

```
run 1: 3 passed (5.5s)   run 4: 3 passed (5.5s)
run 2: 3 passed (5.5s)   run 5: 3 passed (5.4s)
run 3: 3 passed (5.5s)   run 6: 3 passed (5.4s)
```

Then five more after the final polish, also 3 passed each. Eleven consecutive green runs, no retries, no lengthened timeouts, no weakened assertions. Against the same stack on `localhost`, two consecutive cold runs failed 2 of 3 specs each.

## Not verified

The 21 second timeout is the Windows default. A Linux or macOS host with the same dual-stack resolution pays its own connect timeout, which is shorter, so the symptom there is a slow first request rather than a failing suite. Naming the address removes it either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jm8QYgiiBcbrn89Joyc2Tz
