### PR TITLE
Let the rate-limit test spend a budget that leaks while it spends it

### DIFF
--- a/anubis/tests/rate_limit_flow.rs
+++ b/anubis/tests/rate_limit_flow.rs
@@ -16,6 +16,7 @@ use axum::http::{HeaderMap, Request, StatusCode};
 use http_body_util::BodyExt;
 use serde_json::{Value, json};
 use std::net::SocketAddr;
+use std::time::Instant;
 use tower::ServiceExt;
 
 async fn send(
@@ -93,17 +94,51 @@ async fn login_attempts_run_out_per_client_address() {
         "email": format!("nobody-{}@example.com", uuid::Uuid::new_v4()),
         "password": "a wrong password entirely",
     });
-    for attempt in 0..quota {
-        let (status, _headers, body) = send(&router, "/login", &credentials, attacker).await;
+    // The budget leaks continuously rather than resetting on a boundary, so
+    // how many attempts it admits depends on how long they take: one cell
+    // returns every `period / quota`, which is six seconds here. Spending the
+    // budget therefore means sending until the refusal arrives, not sending
+    // exactly `quota` requests and assuming none replenished. Each attempt
+    // costs a real argon2id verification, so on a loaded machine the burst
+    // outlasts an emission interval and the naive count is wrong.
+    let period = anubis::rate_limit::Budget::Credentials.period();
+    let emission = period / quota;
+    // Four budgets' worth: enough that a working limiter always refuses
+    // inside it, few enough that a broken one fails rather than hangs.
+    let ceiling = quota * 4;
+
+    let start = Instant::now();
+    let mut admitted = 0_u32;
+    let mut refusal = None;
+    for attempt in 0..ceiling {
+        let (status, headers, body) = send(&router, "/login", &credentials, attacker).await;
+        if status == StatusCode::TOO_MANY_REQUESTS {
+            refusal = Some((headers, body));
+            break;
+        }
         assert_eq!(
             status,
             StatusCode::UNAUTHORIZED,
-            "attempt {attempt} is within the budget, body: {body}",
+            "attempt {attempt} was admitted, so it must be a plain rejection, body: {body}",
         );
+        admitted += 1;
     }
 
-    let (status, headers, body) = send(&router, "/login", &credentials, attacker).await;
-    assert_eq!(status, StatusCode::TOO_MANY_REQUESTS, "body: {body}");
+    let elapsed = start.elapsed();
+    let (headers, body) = refusal.unwrap_or_else(|| {
+        panic!("the budget never ran out: {admitted} attempts admitted in {elapsed:?}")
+    });
+
+    // What the leak can have returned while the burst was in flight. Asserting
+    // against this rather than against `quota` alone is what makes the test
+    // independent of how slow the machine is, without letting a limiter that
+    // admits everything pass.
+    let replenished = elapsed.as_nanos() / emission.as_nanos();
+    let ceiling_for_run = u128::from(quota) + replenished;
+    assert!(
+        u128::from(admitted) <= ceiling_for_run,
+        "admitted {admitted} in {elapsed:?}, over the budget of {quota} plus {replenished} leaked",
+    );
     let retry_after = headers
         .get(RETRY_AFTER)
         .and_then(|value| value.to_str().ok())


### PR DESCRIPTION
Fixes #102.

The test sent exactly `quota` requests, asserted every one was admitted, then asserted the next was refused. That holds only if the burst finishes before the budget replenishes anything, and nothing said so.

It does not hold. `CREDENTIAL_ATTEMPTS` is ten over one minute and the budget leaks continuously, so a cell returns every six seconds. Every attempt pays a real argon2id verification. Idle, ten attempts take under four seconds and the assertion is true. Loaded, they take over six, a cell has returned, and the eleventh is admitted as a `401`.

Six runs across four unrelated branches tonight, on branches touching only CSS and the CLI stamper:

```
fix-tailwind-source-globs   run 1   FAIL
fix-tailwind-source-globs   rerun   FAIL
fix-new-stamp-fmt           run 1   PASS
subtenant-tier-foundation   run 1   PASS
subtenant-tier-foundation   run 2   FAIL
fix-section-fetch-race      run 1   PASS
```

## The change

Send until refused, then hold the count against what the leak can have returned over the time the burst actually took. That bound comes from the algorithm's own public constants, `quota` plus the whole emission intervals elapsed, so the test states the property it always meant rather than assuming the clock stood still.

It is not weaker. A limiter that refuses on time passes on any machine. One that never refuses exhausts a ceiling of four budgets and fails by name instead of hanging. The refusal's `Retry-After` and message assertions are unchanged and still run, so a run that never saw a `429` cannot pass.

`start_paused` was the fix suggested in the issue and it does not apply: `rate_limit.rs` reads `std::time::Instant`, which tokio's test clock does not control. The limiter already takes its clock as a parameter, which is why its unit tests are deterministic; only the HTTP path calls `Instant::now()`, and reaching that seam from an integration test would mean new public API for a test's benefit.

## Verification

Against a real database, with `CREDENTIAL_ATTEMPTS` untouched:

| Condition | Burst time | Result |
|---|---|---|
| Idle, 3 runs | 3.75 to 3.88s | pass |
| Every core saturated, 3 runs | 8.82 to 9.52s | pass |

The loaded numbers matter: the CI run that failed took 8.17s, so these sit past the boundary that was breaking it.

Full workspace suite green.
